### PR TITLE
Add gitignore to remove doc/tags generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Hello,

I added the .gitignore file so that the generated doc/tags file is not considered by Git. This is useful when you use the plugin as a git submodule of vim configuration.

Thanks in advance,
Stac
